### PR TITLE
test: nominal unit & widget tests for core modules (TIM-6 / Phase 1 A3)

### DIFF
--- a/app/test/modules/calendar/helpers/events_for_planning_view_helper_test.dart
+++ b/app/test/modules/calendar/helpers/events_for_planning_view_helper_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/calendar/helpers/events_for_planning_view_helper.dart';
+
+import '../../../support/fixtures.dart';
+
+void main() {
+  group('getEventsForPlanningView', () {
+    test('returns an empty list for empty input', () {
+      expect(getEventsForPlanningView([]), isEmpty);
+    });
+
+    test('groups events into one EventsByDay entry per day', () {
+      final morning = buildCalendarEvent(
+        uid: 'day1-morning',
+        startsAt: DateTime(2024, 1, 1, 9, 0),
+        endsAt: DateTime(2024, 1, 1, 10, 0),
+      );
+      final afternoon = buildCalendarEvent(
+        uid: 'day1-afternoon',
+        startsAt: DateTime(2024, 1, 1, 14, 0),
+        endsAt: DateTime(2024, 1, 1, 15, 0),
+      );
+      final nextDay = buildCalendarEvent(
+        uid: 'day2',
+        startsAt: DateTime(2024, 1, 2, 9, 0),
+        endsAt: DateTime(2024, 1, 2, 10, 0),
+      );
+
+      final result = getEventsForPlanningView([morning, afternoon, nextDay]);
+
+      expect(result, hasLength(2));
+      expect(result[0].events.map((e) => e.uid), [
+        'day1-morning',
+        'day1-afternoon',
+      ]);
+      expect(result[1].events.map((e) => e.uid), ['day2']);
+    });
+
+    test('sorts the input by startsAt before grouping', () {
+      final first = buildCalendarEvent(
+        uid: 'first',
+        startsAt: DateTime(2024, 1, 1, 9, 0),
+        endsAt: DateTime(2024, 1, 1, 10, 0),
+      );
+      final second = buildCalendarEvent(
+        uid: 'second',
+        startsAt: DateTime(2024, 1, 1, 11, 0),
+        endsAt: DateTime(2024, 1, 1, 12, 0),
+      );
+
+      final result = getEventsForPlanningView([second, first]);
+
+      expect(result, hasLength(1));
+      expect(result[0].events.map((e) => e.uid), ['first', 'second']);
+    });
+  });
+}

--- a/app/test/modules/calendar/helpers/events_for_week_view_helper_test.dart
+++ b/app/test/modules/calendar/helpers/events_for_week_view_helper_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/calendar/helpers/events_for_week_view_helper.dart';
+import 'package:timecalendar/modules/shared/utils/date_utils.dart';
+
+import '../../../support/fixtures.dart';
+
+void main() {
+  // Anchor every fixture to the week's Monday so the test is deterministic and
+  // timezone-independent. `getEventsForWeekView` keeps an event only when it
+  // starts strictly after the day boundary, hence the `+ 9h` offsets.
+  const weekNumber = 1000;
+  final monday = AppDateUtils.dayAtWeekNumber(weekNumber);
+
+  group('getEventsForWeekView', () {
+    test('returns one bucket per day of the week', () {
+      final result = getEventsForWeekView([], weekNumber);
+
+      expect(result, hasLength(7));
+      expect(result.every((day) => day.isEmpty), isTrue);
+    });
+
+    test('places an event in the bucket for its start day', () {
+      final mondayEvent = buildCalendarEvent(
+        uid: 'monday',
+        startsAt: monday.add(const Duration(hours: 9)),
+        endsAt: monday.add(const Duration(hours: 10)),
+      );
+      final wednesdayEvent = buildCalendarEvent(
+        uid: 'wednesday',
+        startsAt: monday.add(const Duration(days: 2, hours: 9)),
+        endsAt: monday.add(const Duration(days: 2, hours: 10)),
+      );
+
+      final result = getEventsForWeekView(
+        [mondayEvent, wednesdayEvent],
+        weekNumber,
+      );
+
+      expect(result[0].map((e) => e.uid), ['monday']);
+      expect(result[2].map((e) => e.uid), ['wednesday']);
+    });
+
+    test('excludes events outside the requested week', () {
+      final beforeWeek = buildCalendarEvent(
+        uid: 'before',
+        startsAt: monday.subtract(const Duration(days: 1)),
+        endsAt: monday.subtract(const Duration(hours: 23)),
+      );
+      final afterWeek = buildCalendarEvent(
+        uid: 'after',
+        startsAt: monday.add(const Duration(days: 8)),
+        endsAt: monday.add(const Duration(days: 8, hours: 1)),
+      );
+
+      final result = getEventsForWeekView([beforeWeek, afterWeek], weekNumber);
+
+      expect(result.every((day) => day.isEmpty), isTrue);
+    });
+  });
+}

--- a/app/test/modules/calendar/helpers/events_helper_test.dart
+++ b/app/test/modules/calendar/helpers/events_helper_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/calendar/helpers/events_helper.dart';
+
+import '../../../support/fixtures.dart';
+
+void main() {
+  group('eventsOverlap', () {
+    test('is true when two events share part of their time range', () {
+      final event1 = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 9, 0),
+        endsAt: DateTime(2024, 1, 1, 10, 30),
+      );
+      final event2 = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 10, 0),
+        endsAt: DateTime(2024, 1, 1, 11, 0),
+      );
+
+      expect(eventsOverlap(event1, event2), isTrue);
+      expect(eventsOverlap(event2, event1), isTrue);
+    });
+
+    test('is false for disjoint events', () {
+      final event1 = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 9, 0),
+        endsAt: DateTime(2024, 1, 1, 10, 0),
+      );
+      final event2 = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 11, 0),
+        endsAt: DateTime(2024, 1, 1, 12, 0),
+      );
+
+      expect(eventsOverlap(event1, event2), isFalse);
+      expect(eventsOverlap(event2, event1), isFalse);
+    });
+  });
+
+  group('eventStartsAtHour / eventEndsAtHour', () {
+    test('return the fractional hour of the event boundaries', () {
+      final event = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 9, 30),
+        endsAt: DateTime(2024, 1, 1, 11, 15),
+      );
+
+      expect(eventStartsAtHour(event), 9.5);
+      expect(eventEndsAtHour(event), 11.25);
+    });
+
+    test('return a whole number when the event starts on the hour', () {
+      final event = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 8, 0),
+        endsAt: DateTime(2024, 1, 1, 10, 0),
+      );
+
+      expect(eventStartsAtHour(event), 8.0);
+      expect(eventEndsAtHour(event), 10.0);
+    });
+  });
+}

--- a/app/test/modules/calendar/models/calendar_event_custom_fields_test.dart
+++ b/app/test/modules/calendar/models/calendar_event_custom_fields_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/calendar/models/calendar_event_custom_fields.dart';
+
+void main() {
+  group('CalendarEventCustomFields', () {
+    test('fromInternalDb then toDbMap round-trips every field', () {
+      final dbMap = <String, dynamic>{
+        'canceled': true,
+        'shortDescription': 'Cours annulé',
+        'subject': 'Mathématiques',
+        'groupColor': '#e66b9a',
+      };
+
+      final roundTripped =
+          CalendarEventCustomFields.fromInternalDb(dbMap).toDbMap();
+
+      expect(roundTripped, equals(dbMap));
+    });
+  });
+}

--- a/app/test/modules/calendar/models/calendar_event_test.dart
+++ b/app/test/modules/calendar/models/calendar_event_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/calendar/models/calendar_event.dart';
+
+void main() {
+  group('CalendarEvent DB serialization', () {
+    test('fromInternalDb then toDbMap round-trips the core fields', () {
+      // Dates are stored as UTC ISO strings, so a UTC input round-trips
+      // exactly through the `toLocal()` / `toUtc()` conversion.
+      final dbMap = <String, dynamic>{
+        'uid': 'event-42',
+        'title': 'Cours de physique',
+        'color': '#3a7bd5',
+        'groupColor': '#e66b9a',
+        'startsAt': '2024-01-08T09:00:00.000Z',
+        'endsAt': '2024-01-08T10:30:00.000Z',
+        'location': 'Amphi B',
+        'allDay': false,
+        'description': 'Optique géométrique',
+        'teachers': ['Mme Martin'],
+        'tags': [
+          {'name': 'TD', 'color': '#00ff00', 'icon': 'book'},
+        ],
+        'fields': {
+          'canceled': false,
+          'shortDescription': 'Optique',
+          'subject': 'Physique',
+          'groupColor': '#e66b9a',
+        },
+        'exportedAt': '2024-01-07T08:00:00.000Z',
+        'userCalendarId': 'calendar-9',
+      };
+
+      final roundTripped = CalendarEvent.fromInternalDb(dbMap).toDbMap();
+
+      expect(roundTripped, equals(dbMap));
+    });
+  });
+}

--- a/app/test/modules/calendar/models/event_tag_test.dart
+++ b/app/test/modules/calendar/models/event_tag_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/calendar/models/event_tag.dart';
+
+void main() {
+  group('EventTag', () {
+    test('fromDb then toDbMap round-trips name, color and icon', () {
+      final dbMap = <String, dynamic>{
+        'name': 'Travaux dirigés',
+        'color': '#00ff00',
+        'icon': 'book',
+      };
+
+      final roundTripped = EventTag.fromDb(dbMap).toDbMap();
+
+      expect(roundTripped, equals(dbMap));
+    });
+
+    test('resolves iconData from the icon string', () {
+      final tag = EventTag.fromDb(const {
+        'name': 'Travaux dirigés',
+        'color': '#00ff00',
+        'icon': 'book',
+      });
+
+      expect(tag.iconData, isA<IconData>());
+      expect(tag.iconData, Icons.book);
+    });
+  });
+}

--- a/app/test/modules/calendar/models/ui/event_for_ui_test.dart
+++ b/app/test/modules/calendar/models/ui/event_for_ui_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/calendar/models/ui/event_for_ui.dart';
+
+import '../../../../support/fixtures.dart';
+
+void main() {
+  group('EventForUI.listFromEvents', () {
+    test('gives each non-overlapping event a single full-width column', () {
+      final morning = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 9, 0),
+        endsAt: DateTime(2024, 1, 1, 10, 0),
+      );
+      final afternoon = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 14, 0),
+        endsAt: DateTime(2024, 1, 1, 15, 0),
+      );
+
+      final result = EventForUI.listFromEvents([morning, afternoon]);
+
+      for (final event in result) {
+        expect(event.columns, 1);
+        expect(event.startColumn, 0);
+        expect(event.endColumn, 1);
+      }
+    });
+
+    test('places two overlapping events in distinct columns', () {
+      final first = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 9, 0),
+        endsAt: DateTime(2024, 1, 1, 10, 30),
+      );
+      final second = buildCalendarEvent(
+        startsAt: DateTime(2024, 1, 1, 10, 0),
+        endsAt: DateTime(2024, 1, 1, 11, 0),
+      );
+
+      final result = EventForUI.listFromEvents([first, second]);
+
+      expect(result.every((e) => e.columns == 2), isTrue);
+      expect(
+        result.map((e) => e.startColumn).toSet(),
+        {0, 1},
+        reason: 'overlapping events must occupy different columns',
+      );
+    });
+
+    test('orders the result by event startsAt', () {
+      final early = buildCalendarEvent(
+        uid: 'early',
+        startsAt: DateTime(2024, 1, 1, 9, 0),
+        endsAt: DateTime(2024, 1, 1, 10, 0),
+      );
+      final late = buildCalendarEvent(
+        uid: 'late',
+        startsAt: DateTime(2024, 1, 1, 11, 0),
+        endsAt: DateTime(2024, 1, 1, 12, 0),
+      );
+
+      final result = EventForUI.listFromEvents([late, early]);
+
+      expect(result.map((e) => e.event.uid), ['early', 'late']);
+    });
+  });
+}

--- a/app/test/modules/event_details/controllers/checklist_focus_controller_test.dart
+++ b/app/test/modules/event_details/controllers/checklist_focus_controller_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/event_details/controllers/checklist_focus_controller.dart';
+import 'package:timecalendar/modules/event_details/models/checklist_item.dart';
+
+void main() {
+  group('ChecklistFocusController', () {
+    test('invokes listeners passed to the constructor on focusItem', () {
+      final focused = <ChecklistItem>[];
+      final controller = ChecklistFocusController([focused.add]);
+      final item = ChecklistItem(content: 'Note');
+
+      controller.focusItem(item);
+
+      expect(focused, [item]);
+    });
+
+    test('addListener registers a new listener', () {
+      final focused = <ChecklistItem>[];
+      final controller = ChecklistFocusController([]);
+      final item = ChecklistItem(content: 'Note');
+
+      controller.addListener(focused.add);
+      controller.focusItem(item);
+
+      expect(focused, [item]);
+    });
+
+    test('removeListener stops a listener from being notified', () {
+      final focused = <ChecklistItem>[];
+      void listener(ChecklistItem item) => focused.add(item);
+      final controller = ChecklistFocusController([listener]);
+
+      controller.removeListener(listener);
+      controller.focusItem(ChecklistItem(content: 'Note'));
+
+      expect(focused, isEmpty);
+    });
+  });
+}

--- a/app/test/modules/event_details/models/checklist_item_test.dart
+++ b/app/test/modules/event_details/models/checklist_item_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/event_details/models/checklist_item.dart';
+
+void main() {
+  group('ChecklistItem', () {
+    test('fromMap then toMap round-trips every field', () {
+      final map = <String, dynamic>{
+        'uuid': 'item-1',
+        'eventUid': 'event-1',
+        'content': 'Réviser le chapitre 3',
+        'isChecked': true,
+        'order': 2,
+        'createdAt': '2024-01-01T09:00:00.000Z',
+        'updatedAt': '2024-01-02T10:30:00.000Z',
+        'deletedAt': '2024-01-03T11:45:00.000Z',
+      };
+
+      final roundTripped = ChecklistItem.fromMap(map).toMap();
+
+      expect(roundTripped, equals(map));
+    });
+
+    test('auto-generates a uuid when none is provided', () {
+      final item = ChecklistItem(content: 'Acheter un cahier');
+
+      expect(item.uuid, isNotNull);
+      expect(item.uuid, isNotEmpty);
+    });
+
+    test('keeps a uuid that was explicitly provided', () {
+      final item = ChecklistItem(uuid: 'fixed-uuid', content: 'Note');
+
+      expect(item.uuid, 'fixed-uuid');
+    });
+
+    test('parses and serializes ISO date strings', () {
+      final item = ChecklistItem.fromMap(const {
+        'uuid': 'item-1',
+        'content': 'Note',
+        'createdAt': '2024-01-01T09:00:00.000Z',
+      });
+
+      expect(item.createdAt, DateTime.parse('2024-01-01T09:00:00.000Z'));
+      expect(item.updatedAt, isNull);
+      expect(item.toMap()['createdAt'], '2024-01-01T09:00:00.000Z');
+    });
+  });
+}

--- a/app/test/modules/event_details/widgets/event_details_checklist_item_test.dart
+++ b/app/test/modules/event_details/widgets/event_details_checklist_item_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/event_details/controllers/checklist_focus_controller.dart';
+import 'package:timecalendar/modules/event_details/models/checklist_item.dart';
+import 'package:timecalendar/modules/event_details/widgets/event_details_checklist_item.dart';
+
+import '../../../support/pump_app.dart';
+
+void main() {
+  // The widget reads `checklistItem.content!`, so the fixture must be non-null.
+  ChecklistItem buildItem({bool isChecked = false}) => ChecklistItem(
+    uuid: 'item-1',
+    content: 'Réviser le chapitre 3',
+    isChecked: isChecked,
+  );
+
+  Widget buildWidget(
+    ChecklistItem item, {
+    void Function(ChecklistItem, dynamic)? onCheckChanged,
+    void Function(ChecklistItem)? removeItem,
+  }) {
+    return EventDetailsChecklistItem(
+      checklistItem: item,
+      checklistFocusController: ChecklistFocusController([]),
+      removeItem: removeItem ?? (_) {},
+      onContentChanged: (_, __) {},
+      onCheckChanged: onCheckChanged ?? (_, __) {},
+    );
+  }
+
+  group('EventDetailsChecklistItem', () {
+    testWidgets('renders the item content in the text field', (tester) async {
+      await tester.pumpApp(buildWidget(buildItem()));
+      await tester.pump(Duration.zero);
+
+      expect(find.text('Réviser le chapitre 3'), findsOneWidget);
+    });
+
+    testWidgets('reflects the checked state on the checkbox', (tester) async {
+      await tester.pumpApp(buildWidget(buildItem(isChecked: true)));
+      await tester.pump(Duration.zero);
+
+      final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+      expect(checkbox.value, isTrue);
+    });
+
+    testWidgets('calls onCheckChanged when the checkbox is tapped', (
+      tester,
+    ) async {
+      final item = buildItem(isChecked: true);
+      ChecklistItem? changedItem;
+      dynamic changedValue;
+
+      await tester.pumpApp(
+        buildWidget(
+          item,
+          onCheckChanged: (i, v) {
+            changedItem = i;
+            changedValue = v;
+          },
+        ),
+      );
+      await tester.pump(Duration.zero);
+
+      await tester.tap(find.byType(Checkbox));
+      await tester.pump(Duration.zero);
+
+      expect(changedItem, same(item));
+      expect(changedValue, isFalse);
+    });
+
+    testWidgets('calls removeItem when the close icon is tapped', (
+      tester,
+    ) async {
+      final item = buildItem();
+      ChecklistItem? removed;
+
+      await tester.pumpApp(buildWidget(item, removeItem: (i) => removed = i));
+      await tester.pump(Duration.zero);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump(Duration.zero);
+
+      expect(removed, same(item));
+    });
+  });
+}

--- a/app/test/modules/onboarding/screens/onboarding_screen_test.dart
+++ b/app/test/modules/onboarding/screens/onboarding_screen_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:timecalendar/modules/onboarding/screens/onboarding_screen.dart';
+import 'package:timecalendar/modules/settings/providers/settings_provider.dart';
+
+import '../../../support/pump_app.dart';
+import '../../../support/settings_provider.dart';
+
+void main() {
+  // `OnboardingScreen.initState` reads `SettingsProvider` through the legacy
+  // `provider` package, so the screen needs a `ChangeNotifierProvider` wrapper
+  // around a provider that has already loaded its settings.
+  late SettingsProvider settings;
+
+  setUp(() async {
+    settings = await loadSettingsProvider();
+  });
+
+  Widget buildSubject() => ChangeNotifierProvider<SettingsProvider>.value(
+    value: settings,
+    child: OnboardingScreen(),
+  );
+
+  group('OnboardingScreen', () {
+    testWidgets('renders the first page and its navigation controls', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Consultez votre agenda'), findsOneWidget);
+      expect(find.text('Passer'), findsOneWidget);
+      expect(find.text('Suivant'), findsOneWidget);
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.controller!.page, 0);
+    });
+
+    testWidgets('advances to the second page when "Suivant" is tapped', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Suivant'));
+      await tester.pumpAndSettle();
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.controller!.page, 1);
+    });
+  });
+}

--- a/app/test/modules/school/controllers/school_selection_controller_test.dart
+++ b/app/test/modules/school/controllers/school_selection_controller_test.dart
@@ -1,0 +1,109 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:timecalendar/modules/school/controllers/school_selection_controller.dart';
+import 'package:timecalendar/modules/shared/clients/timecalendar_client.dart';
+import 'package:timecalendar_api/timecalendar_api.dart';
+
+import '../../../support/fixtures.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
+
+class MockSchoolsApi extends Mock implements SchoolsApi {}
+
+/// A [SchoolSelectionController] pre-seeded with data, so `schoolFilteredProvider`
+/// can be exercised without driving the async `fetch()`.
+class _SeededSchoolController extends SchoolSelectionController {
+  _SeededSchoolController(BuiltList<SchoolForList> schools)
+    : super(client: MockApiClient()) {
+    state = AsyncValue.data(schools);
+  }
+}
+
+void main() {
+  group('SchoolSelectionController.fetch', () {
+    test('sets state to AsyncData with the fetched schools', () async {
+      final schools = [
+        buildSchoolForList(id: 'a', code: 'SORB', name: 'Sorbonne'),
+        buildSchoolForList(id: 'b', code: 'XYZ', name: 'Polytechnique'),
+      ];
+      final client = MockApiClient();
+      final schoolsApi = MockSchoolsApi();
+      when(() => client.schoolsApi()).thenReturn(schoolsApi);
+      when(() => schoolsApi.findSchools()).thenAnswer(
+        (_) async => Response(
+          requestOptions: RequestOptions(path: '/schools'),
+          data: buildFindSchoolsRep(schools),
+        ),
+      );
+
+      final controller = SchoolSelectionController(client: client);
+      AsyncValue<BuiltList<SchoolForList>>? observedState;
+      controller.addListener((state) => observedState = state);
+
+      final result = await controller.fetch();
+
+      expect(result.map((s) => s.id), ['a', 'b']);
+      expect(observedState, isA<AsyncData<BuiltList<SchoolForList>>>());
+      expect(observedState!.value, equals(result));
+    });
+  });
+
+  group('schoolFilteredProvider', () {
+    final sorbonne = buildSchoolForList(
+      id: 'a',
+      code: 'SORB',
+      name: 'Sorbonne',
+    );
+    final polytechnique = buildSchoolForList(
+      id: 'b',
+      code: 'XYZ',
+      name: 'Polytechnique',
+    );
+
+    ProviderContainer seededContainer() {
+      final container = ProviderContainer(
+        overrides: [
+          schoolSelectionControllerProvider.overrideWith(
+            (ref) => _SeededSchoolController(
+              BuiltList<SchoolForList>([sorbonne, polytechnique]),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('returns every school when the search is empty', () {
+      final container = seededContainer();
+
+      expect(
+        container.read(schoolFilteredProvider).map((s) => s.id),
+        ['a', 'b'],
+      );
+    });
+
+    test('filters by school name', () {
+      final container = seededContainer();
+      container.read(schoolSearchProvider.notifier).state = 'sorbonne';
+
+      expect(
+        container.read(schoolFilteredProvider).map((s) => s.id),
+        ['a'],
+      );
+    });
+
+    test('filters by school code', () {
+      final container = seededContainer();
+      container.read(schoolSearchProvider.notifier).state = 'xyz';
+
+      expect(
+        container.read(schoolFilteredProvider).map((s) => s.id),
+        ['b'],
+      );
+    });
+  });
+}

--- a/app/test/modules/settings/providers/settings_provider_test.dart
+++ b/app/test/modules/settings/providers/settings_provider_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:timecalendar/modules/calendar/models/ui/calendar_view_type.dart';
+
+import '../../../support/fixtures.dart';
+import '../../../support/settings_provider.dart';
+
+void main() {
+  group('SettingsProvider.loadSettings', () {
+    test('populates the documented defaults when prefs are empty', () async {
+      final provider = await loadSettingsProvider();
+
+      expect(provider.dateLimit, 14);
+      expect(provider.calendarHourHeight, 60);
+      expect(provider.calendarViewType, CalendarViewType.Week);
+    });
+  });
+
+  group('SettingsProvider event color helpers', () {
+    test('getEventColorToSave / getEventColorToDisplay return null for null',
+        () async {
+      final provider = await loadSettingsProvider();
+
+      expect(provider.getEventColorToSave(null), isNull);
+      expect(provider.getEventColorToDisplay(null), isNull);
+    });
+
+    test('getEventInterfaceColor uses event.color when colorsByGroup is false',
+        () async {
+      final provider = await loadSettingsProvider({'theme': 'light'});
+      final event = buildCalendarEvent();
+
+      expect(provider.colorsByGroup, isFalse);
+      expect(provider.getEventInterfaceColor(event), event.color);
+    });
+
+    test('getEventInterfaceColor uses event.groupColor when colorsByGroup is true',
+        () async {
+      final provider = await loadSettingsProvider({
+        'theme': 'light',
+        'colors_by_group': true,
+      });
+      final event = buildCalendarEvent();
+
+      expect(provider.colorsByGroup, isTrue);
+      expect(provider.getEventInterfaceColor(event), event.groupColor);
+    });
+  });
+}

--- a/app/test/support/fixtures.dart
+++ b/app/test/support/fixtures.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:timecalendar/modules/calendar/models/calendar_event.dart';
+import 'package:timecalendar/modules/calendar/models/calendar_event_custom_fields.dart';
+import 'package:timecalendar/modules/calendar/models/event_tag.dart';
+import 'package:timecalendar_api/timecalendar_api.dart'
+    show FindSchoolsRepDto, SchoolAssistant, SchoolForList;
+
+/// Shared domain-object builders for tests.
+///
+/// Each builder fills every required field with a sane default and exposes
+/// those fields as named parameters so a test only states what it cares about.
+/// Test-only — this file lives under `test/support/` and is never shipped.
+
+/// Builds a [CalendarEvent] (which implements `EventInterface`), so it doubles
+/// as the fixture for the calendar helper and `EventForUI` tests.
+CalendarEvent buildCalendarEvent({
+  String uid = 'event-1',
+  String title = 'Cours de mathématiques',
+  Color color = const Color(0xFF3A7BD5),
+  Color groupColor = const Color(0xFFE66B9A),
+  DateTime? startsAt,
+  DateTime? endsAt,
+  String? location = 'Salle A1',
+  bool allDay = false,
+  String? description = 'Chapitre 3',
+  List<String>? teachers,
+  List<EventTag>? tags,
+  CalendarEventCustomFields? fields,
+  DateTime? exportedAt,
+  String userCalendarId = 'calendar-1',
+}) {
+  return CalendarEvent(
+    uid: uid,
+    title: title,
+    color: color,
+    groupColor: groupColor,
+    startsAt: startsAt ?? DateTime(2024, 1, 1, 9, 0),
+    endsAt: endsAt ?? DateTime(2024, 1, 1, 10, 0),
+    location: location,
+    allDay: allDay,
+    description: description,
+    teachers: teachers ?? const ['M. Dupont'],
+    tags: tags ?? const [],
+    fields: fields,
+    exportedAt: exportedAt ?? DateTime(2024, 1, 1, 8, 0),
+    userCalendarId: userCalendarId,
+  );
+}
+
+/// Builds a built_value [SchoolForList], including its required nested
+/// [SchoolAssistant].
+SchoolForList buildSchoolForList({
+  String id = 'school-1',
+  String code = 'TC',
+  String name = 'TimeCalendar University',
+  String slug = 'native',
+}) {
+  final assistant = SchoolAssistant(
+    (b) => b
+      ..slug = slug
+      ..requireIntranetAccess = false
+      ..requireCalendarName = false
+      ..isNative = true,
+  );
+
+  return SchoolForList(
+    (b) => b
+      ..id = id
+      ..code = code
+      ..name = name
+      ..siteUrl = 'https://example.com'
+      ..imageUrl = 'https://example.com/logo.png'
+      ..visible = true
+      ..createdAt = DateTime.utc(2024, 1, 1)
+      ..updatedAt = DateTime.utc(2024, 1, 1)
+      ..assistant.replace(assistant),
+  );
+}
+
+/// Wraps [schools] in a [FindSchoolsRepDto] — the payload of `findSchools()`.
+FindSchoolsRepDto buildFindSchoolsRep(List<SchoolForList> schools) {
+  return FindSchoolsRepDto((b) => b..schools.replace(schools));
+}

--- a/app/test/support/settings_provider.dart
+++ b/app/test/support/settings_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timecalendar/modules/settings/providers/settings_provider.dart';
+
+/// Builds a [SettingsProvider] that has already run `loadSettings`.
+///
+/// `SettingsProvider` is a process-wide singleton that reads `SharedPreferences`
+/// and `PackageInfo` on load, so this mocks both plugin channels first.
+/// `setMockInitialValues` also clears any cached `SharedPreferences` instance,
+/// giving each test a known starting state from [prefs].
+Future<SettingsProvider> loadSettingsProvider([
+  Map<String, Object> prefs = const {},
+]) async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues(prefs);
+  PackageInfo.setMockInitialValues(
+    appName: 'TimeCalendar',
+    packageName: 'com.timecalendar',
+    version: '1.0.0',
+    buildNumber: '1',
+    buildSignature: '',
+  );
+  final provider = SettingsProvider();
+  await provider.loadSettings(await SharedPreferences.getInstance());
+  return provider;
+}

--- a/openspec/changes/nominal-core-module-tests/.openspec.yaml
+++ b/openspec/changes/nominal-core-module-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/nominal-core-module-tests/design.md
+++ b/openspec/changes/nominal-core-module-tests/design.md
@@ -1,0 +1,108 @@
+## Context
+
+A1 (`flutter-test-foundation`) delivered the harness: `mocktail`, the
+`test/` ⇄ `lib/modules/` mirror layout, the `pumpApp` widget helper
+(`test/support/pump_app.dart`), and `test/README.md`. A3 is the first change
+to actually use it at scale. The constraint is to add *nominal* coverage —
+the happy path of each piece of core logic — without chasing edge cases or
+touching production code.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Regression tests for the highest-value logic in `app/lib/modules/`.
+- Each test file independently runnable and verifiable (`flutter test <file>`).
+- Tests follow the A1 exemplars and `README.md` patterns exactly.
+
+**Non-Goals:**
+- Coverage targets; error-path / edge-case exhaustion.
+- Production code changes, refactors, or making hard-to-test code testable
+  by changing it (flag such code instead — see Risks).
+- E2E/integration tests (TIM-5) and CI changes (already done in A1).
+
+## Module selection — why these
+
+The candidate list was triaged by **regression value per line of test code**.
+Pure logic with branching or arithmetic is included; thin pass-through code and
+plugin-bound UI are deprioritised.
+
+| Module / file | Included | Rationale |
+|---|---|---|
+| `calendar/helpers/*` | ✅ | Pure functions, no Flutter binding — overlap math and date bucketing feed every calendar view. Highest value/line. |
+| `calendar/models/ui/event_for_ui.dart` | ✅ | The column-placement algorithm for overlapping events — the most intricate logic in the app and the easiest to break silently. |
+| `calendar/models/{calendar_event,event_tag,calendar_event_custom_fields}.dart` | ✅ | DB serialization round-trips; a broken `toDbMap`/`fromInternalDb` corrupts the local cache. |
+| `event_details/models/checklist_item.dart` | ✅ | Map round-trip + uuid auto-generation; same serialization-regression risk. |
+| `event_details/controllers/checklist_focus_controller.dart` | ✅ | Small, pure, fully deterministic listener registry — cheap to lock down. |
+| `event_details/widgets/event_details_checklist_item.dart` | ✅ | The one checklist widget with real interaction logic (checkbox, text edit, remove) and **no** provider/plugin coupling — the natural widget-test exemplar for A3. |
+| `school/controllers/school_selection_controller.dart` | ✅ | `fetch()` happy path + `schoolFilteredProvider` filtering; exercises the mocktail-mocked API-client pattern end to end. |
+| `settings/providers/settings_provider.dart` | ✅ | `loadSettings` defaulting logic and the color/theme helpers; needs plugin mock-values (see below) but the defaulting logic is genuinely worth guarding. |
+| `onboarding/screens/onboarding_screen.dart` | ✅ (lowest priority) | Named candidate; included for widget-test breadth. It is pure presentational UI with the most test friction (legacy `provider` + SharedPreferences in `initState`) and the least logic — do it last; it may be dropped if the `initState` coupling proves costly, without affecting the rest of the change. |
+| `calendar` controllers/providers/repositories/services, other widgets | ❌ | Need Riverpod wiring, sembast, or Firebase — disproportionate setup for nominal scope; defer to a later coverage pass. |
+
+## Decisions
+
+**Shared fixture builders in `test/support/fixtures.dart`.** Several domain
+objects (`CalendarEvent`, the built_value `SchoolForList`/`FindSchoolsRepDto`)
+have long required-argument lists. A `buildCalendarEvent({...})` /
+`buildSchoolForList({...})` builder with sensible defaults keeps tests
+readable and means a future constructor change updates one place. This sits in
+`test/support/` next to `pump_app.dart` — test-only, never shipped.
+`CalendarEvent` implements `EventInterface`, so `buildCalendarEvent` doubles as
+the fixture for every helper/`EventForUI` test.
+
+**calendar helpers — plain `test()`/`group()`.** No Flutter binding; follow the
+`ColorUtils` exemplar. `getEventsForWeekView` uses
+`AppDateUtils.dayAtWeekNumber` — week 0 begins on the first Monday on/after
+2000-01-01 (2000-01-03); fixtures place events relative to that anchor so the
+tests are deterministic and timezone-independent.
+
+**school controller — mock the `ApiClient` chain.** `SchoolSelectionController`
+takes an injected `ApiClient`; the test constructs it directly with a
+`MockApiClient` whose `schoolsApi()` returns a `MockSchoolsApi` whose
+`findSchools()` resolves to a `Response<FindSchoolsRepDto>`. This tests the
+controller without `apiClientProvider`/`dio`. `schoolFilteredProvider` is tested
+in a `ProviderContainer` that overrides `schoolSelectionControllerProvider` with
+a seeded state and drives `schoolSearchProvider`. Register `mocktail` fallback
+values in `setUpAll` per the README.
+
+**settings provider — plugin mock-values, not channel stubs.**
+`SettingsProvider.loadSettings` reads `shared_preferences`, `pref`
+(`PrefServiceShared`) and `package_info_plus`. The test calls
+`TestWidgetsFlutterBinding.ensureInitialized()` then
+`SharedPreferences.setMockInitialValues({})` and
+`PackageInfo.setMockInitialValues(...)` — the standard test APIs — so no raw
+`MethodChannel` mocking is needed. `SettingsProvider` is a singleton
+(`factory` returns `_instance`); each test re-runs `loadSettings` to get a known
+state, and tests do not assume isolation beyond that.
+
+**onboarding widget — legacy `provider` wrapper.** `OnboardingScreen.initState`
+calls `Provider.of<SettingsProvider>(context, listen: false)`, so `pumpApp`
+alone is insufficient: wrap the screen in a
+`ChangeNotifierProvider<SettingsProvider>.value`. Because the `currentVersion`
+setter writes to `SharedPreferences`, the provided `SettingsProvider` must have
+`loadSettings` run against `SharedPreferences.setMockInitialValues` first, or
+the post-frame microtask throws a `LateInitializationError` on `prefs`.
+
+## Risks / Trade-offs
+
+- **`settings_provider` is a process-wide singleton.** Tests share one
+  instance; mitigated by re-running `loadSettings` per test. If cross-test
+  bleed appears, note it for the Simplify/Review stages rather than refactoring
+  `lib/` here.
+- **`onboarding_screen` is hard to test for low value.** Its `initState`
+  side-effect couples it to two plugins. The task is sequenced last and is
+  explicitly droppable; the rest of the change does not depend on it.
+- **built_value fixtures for `SchoolForList` are verbose** (nested required
+  `SchoolAssistant`). Centralising them in `fixtures.dart` contains the cost.
+- **No edge cases by design.** Null/empty/error paths are out of scope; a
+  follow-up change can deepen coverage once the nominal suite is green.
+
+## Migration Plan
+
+Additive only — new files under `app/test/`. No `lib/`, `pubspec.yaml` or CI
+changes. Reverting the change deletes the test files with no other effect.
+
+## Open Questions
+
+- None blocking. Whether `onboarding_screen` coverage is worth its setup cost
+  is left to the Applier's judgement during implementation (see task 8).

--- a/openspec/changes/nominal-core-module-tests/proposal.md
+++ b/openspec/changes/nominal-core-module-tests/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+The `flutter-test-foundation` change (TIM-4 / A1) gave the app a test harness, a
+mocking strategy and two exemplar tests — but no real coverage. Today a
+regression in core calendar logic, event-detail serialization or settings
+defaults ships silently: nothing fails. This change (TIM-6 / A3) adds
+*nominal, happy-path* tests to the highest-value modules so regressions in the
+logic the app depends on every launch surface in `flutter test`.
+
+This is **not** a coverage-percentage exercise. The target is regression
+safety per line of test code: pure logic (helpers, models, controllers,
+providers) first, a few widget tests for interactive components second.
+
+## What Changes
+
+Add unit and widget tests under `app/test/`, mirroring `app/lib/modules/`,
+following the patterns in `app/test/README.md` and the two exemplar tests.
+No production (`lib/`) code changes.
+
+- **Test fixtures** — a shared `test/support/fixtures.dart` with builders
+  (`buildCalendarEvent`, `buildSchoolForList`, …) so tests construct domain
+  objects without repeating long required-argument lists.
+- **calendar (highest value — pure algorithmic logic):**
+  - `helpers/events_helper.dart` — overlap detection and fractional-hour math.
+  - `helpers/events_for_week_view_helper.dart` — week bucketing.
+  - `helpers/events_for_planning_view_helper.dart` — per-day grouping.
+  - `models/ui/event_for_ui.dart` — the column-layout algorithm for
+    overlapping events (the most intricate logic in the app).
+  - `models/calendar_event.dart`, `models/event_tag.dart`,
+    `models/calendar_event_custom_fields.dart` — DB serialization round-trips.
+- **event_details:**
+  - `models/checklist_item.dart` — map round-trip + uuid auto-generation.
+  - `controllers/checklist_focus_controller.dart` — listener register/notify/remove.
+  - `widgets/event_details_checklist_item.dart` — a widget test for the one
+    checklist widget with real interaction logic (checkbox, edit, remove).
+- **school:**
+  - `controllers/school_selection_controller.dart` — `fetch()` happy path and
+    the `schoolFilteredProvider` name/code filter.
+- **settings:**
+  - `providers/settings_provider.dart` — `loadSettings` defaults and the pure
+    color/theme helper methods.
+- **onboarding:**
+  - `screens/onboarding_screen.dart` — a widget test: first page renders,
+    skip/next controls present, "Suivant" advances the carousel.
+
+Non-goals: 100% coverage, error/edge-case exhaustion, E2E/integration tests
+(A2 — TIM-5), production code changes or refactors, and CI changes (the
+`test-app` job from A1 already runs the whole `app/test/` tree).
+
+## Capabilities
+
+### New Capabilities
+- `core-module-test-coverage`: nominal regression tests for the core Flutter
+  modules — one requirement per module (calendar, event_details, school,
+  settings, onboarding) describing the logic that `flutter test` now guards.
+
+### Modified Capabilities
+<!-- None — `flutter-test-harness` is unchanged; this change consumes it. -->
+
+## Impact
+
+- `app/test/support/fixtures.dart` — new shared test-fixture builders.
+- `app/test/modules/calendar/**` — new test files for helpers and models.
+- `app/test/modules/event_details/**` — new test files for model, controller, widget.
+- `app/test/modules/school/**` — new test file for the selection controller/provider.
+- `app/test/modules/settings/**` — new test file for the settings provider.
+- `app/test/modules/onboarding/**` — new widget test file.
+- No `lib/` changes; app behaviour is unchanged. No `pubspec.yaml` or CI changes.

--- a/openspec/changes/nominal-core-module-tests/specs/core-module-test-coverage/spec.md
+++ b/openspec/changes/nominal-core-module-tests/specs/core-module-test-coverage/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Shared domain-object fixtures
+
+The test suite SHALL provide reusable fixture builders under `app/test/support/`
+that construct core domain objects (calendar events, school list entries) with
+sensible defaults, so tests do not repeat long required-argument lists.
+
+#### Scenario: A test builds a calendar event fixture
+
+- **WHEN** a test calls the shared `buildCalendarEvent` helper with zero or more overrides
+- **THEN** it receives a valid `CalendarEvent` (which implements `EventInterface`) with all required fields populated and any overrides applied
+
+### Requirement: Calendar logic coverage
+
+The `calendar` module's pure logic SHALL have nominal regression tests:
+the event helpers, the `EventForUI` column-layout algorithm, and the model
+serialization round-trips.
+
+#### Scenario: Event helper functions are exercised
+
+- **WHEN** `flutter test` runs the `calendar/helpers` tests
+- **THEN** `eventsOverlap` is verified for overlapping and disjoint events, `eventStartsAtHour`/`eventEndsAtHour` are verified for fractional hours, `getEventsForWeekView` is verified to bucket events into the correct day of the requested week, and `getEventsForPlanningView` is verified to group events per day and return an empty list for empty input
+
+#### Scenario: Overlapping-event layout is exercised
+
+- **WHEN** `flutter test` runs the `EventForUI` test
+- **THEN** `EventForUI.listFromEvents` is verified to leave non-overlapping events at a single column and to assign two overlapping events to distinct columns with a column count of two
+
+#### Scenario: Calendar model serialization round-trips
+
+- **WHEN** `flutter test` runs the `calendar/models` tests
+- **THEN** `CalendarEvent`, `EventTag` and `CalendarEventCustomFields` are each verified to round-trip through their `fromInternalDb`/`fromDb` and `toDbMap` methods without losing field values
+
+### Requirement: Event-details coverage
+
+The `event_details` module SHALL have nominal regression tests for the
+`ChecklistItem` model, the `ChecklistFocusController`, and the
+`EventDetailsChecklistItem` widget.
+
+#### Scenario: Checklist item model and focus controller are exercised
+
+- **WHEN** `flutter test` runs the `event_details` model and controller tests
+- **THEN** `ChecklistItem` is verified to round-trip through `fromMap`/`toMap` and to auto-generate a `uuid` when none is supplied, and `ChecklistFocusController` is verified to invoke registered listeners on `focusItem` and to stop invoking a listener after `removeListener`
+
+#### Scenario: Checklist item widget is exercised
+
+- **WHEN** `flutter test` runs the `EventDetailsChecklistItem` widget test
+- **THEN** the widget is verified to render the item content, to reflect the item's checked state, and to invoke its callbacks when the checkbox and the remove control are tapped
+
+### Requirement: School selection coverage
+
+The `school` module SHALL have nominal regression tests for the happy path of
+`SchoolSelectionController` and `schoolFilteredProvider`.
+
+#### Scenario: School fetch and filter are exercised
+
+- **WHEN** `flutter test` runs the `school` controller test
+- **THEN** `SchoolSelectionController.fetch()` is verified, with a mocked API client, to populate state with the returned schools, and `schoolFilteredProvider` is verified to filter the school list by both school name and school code
+
+### Requirement: Settings provider coverage
+
+The `settings` module's `SettingsProvider` SHALL have nominal regression tests
+for its default-loading logic and its pure color/theme helper methods.
+
+#### Scenario: Settings defaults and helpers are exercised
+
+- **WHEN** `flutter test` runs the `SettingsProvider` test with mocked plugin values
+- **THEN** `loadSettings` is verified to populate the documented default values, and `getEventColorToSave`, `getEventColorToDisplay` and `getEventInterfaceColor` are verified for their nominal inputs
+
+### Requirement: Onboarding screen coverage
+
+The `onboarding` module's `OnboardingScreen` SHALL have a nominal widget test
+covering rendering and carousel navigation.
+
+#### Scenario: Onboarding screen renders and advances
+
+- **WHEN** `flutter test` runs the `OnboardingScreen` widget test
+- **THEN** the first onboarding page and its skip/next controls are verified to render, and advancing the carousel via the next control is verified to move to the second page

--- a/openspec/changes/nominal-core-module-tests/tasks.md
+++ b/openspec/changes/nominal-core-module-tests/tasks.md
@@ -1,0 +1,114 @@
+# Tasks
+
+Conventions for every task below:
+- Test files mirror `lib/`: a test for `lib/modules/<m>/<p>/<f>.dart` lives at
+  `test/modules/<m>/<p>/<f>_test.dart` (run from `app/`).
+- Follow `app/test/README.md` and the exemplars
+  (`test/modules/shared/utils/color_utils_test.dart` for pure unit tests,
+  `test/modules/shared/widgets/ui/custom_button_test.dart` for widget tests).
+- Mock with `mocktail`; register fallback values in `setUpAll`.
+- Flutter SDK is not on `PATH`: `export PATH="/home/dev/flutter/bin:$PATH"`,
+  run from `app/`.
+- Each task is independently verifiable: `flutter test <file>` must pass and
+  `flutter analyze <file>` must report no new issues.
+- Tests are **nominal / happy-path only** — no error or edge-case exhaustion.
+
+## 1. Shared test fixtures
+
+- [ ] 1.1 Create `app/test/support/fixtures.dart` with a `buildCalendarEvent({...})`
+  builder returning a `CalendarEvent` (implements `EventInterface`) with sane
+  defaults for every required field, each overridable — at minimum `uid`,
+  `title`, `startsAt`, `endsAt`, `color`, `groupColor`. Used by tasks 2–3.
+- [ ] 1.2 In the same file add `buildSchoolForList({...})` (built_value
+  `SchoolForListBuilder`, including the required nested `SchoolAssistant`) and
+  `buildFindSchoolsRep(List<SchoolForList>)` returning a `FindSchoolsRepDto`.
+  Used by task 6.
+
+## 2. calendar — pure helpers
+
+- [ ] 2.1 `test/modules/calendar/helpers/events_helper_test.dart` —
+  `eventsOverlap` true for overlapping events, false for disjoint events;
+  `eventStartsAtHour` / `eventEndsAtHour` return the expected fractional hour
+  (e.g. 09:30 → 9.5).
+- [ ] 2.2 `test/modules/calendar/helpers/events_for_week_view_helper_test.dart` —
+  `getEventsForWeekView` returns a list of 7 day-buckets; an event is placed in
+  the bucket for its start day; an event outside the requested week is excluded.
+  Anchor fixtures to `AppDateUtils.dayAtWeekNumber(weekNumber)`.
+- [ ] 2.3 `test/modules/calendar/helpers/events_for_planning_view_helper_test.dart` —
+  `getEventsForPlanningView` returns `[]` for empty input; groups events into
+  per-day `EventsByDay` entries; input is sorted by `startsAt`.
+
+## 3. calendar — event layout model
+
+- [ ] 3.1 `test/modules/calendar/models/ui/event_for_ui_test.dart` —
+  `EventForUI.listFromEvents`: non-overlapping events each get `columns == 1`,
+  `startColumn == 0`, `endColumn == 1`; two overlapping events get distinct
+  columns and `columns == 2`; the result is ordered by `event.startsAt`.
+
+## 4. calendar — model serialization
+
+- [ ] 4.1 `test/modules/calendar/models/calendar_event_test.dart` —
+  `CalendarEvent.fromInternalDb(map)` then `.toDbMap()` round-trips the core
+  fields (uid, title, colors, dates, location, tags, fields).
+- [ ] 4.2 `test/modules/calendar/models/event_tag_test.dart` —
+  `EventTag.fromDb` → `toDbMap` round-trip preserves `name`/`color`/`icon`;
+  `iconData` is populated (a non-null `IconData`) from the `icon` string.
+- [ ] 4.3 `test/modules/calendar/models/calendar_event_custom_fields_test.dart` —
+  `CalendarEventCustomFields.fromInternalDb` → `toDbMap` round-trips
+  `canceled`, `shortDescription`, `subject`, `groupColor`.
+
+## 5. event_details
+
+- [ ] 5.1 `test/modules/event_details/models/checklist_item_test.dart` —
+  `ChecklistItem.fromMap` → `toMap` round-trip; the constructor auto-generates a
+  `uuid` when none is passed; ISO date strings parse and serialize correctly.
+- [ ] 5.2 `test/modules/event_details/controllers/checklist_focus_controller_test.dart` —
+  listeners passed to the constructor are invoked by `focusItem`;
+  `addListener` registers a new listener; `removeListener` stops notifications.
+- [ ] 5.3 `test/modules/event_details/widgets/event_details_checklist_item_test.dart`
+  (widget test via `pumpApp`) — renders the item content in the `TextField`;
+  the `Checkbox` reflects `checklistItem.isChecked`; tapping the checkbox calls
+  `onCheckChanged` and tapping the close icon calls `removeItem`. Provide a
+  `ChecklistItem` with non-null `content` (the widget reads `content!`).
+
+## 6. school
+
+- [ ] 6.1 `test/modules/school/controllers/school_selection_controller_test.dart` —
+  construct `SchoolSelectionController` with a `mocktail`-mocked `ApiClient`
+  whose `schoolsApi().findSchools()` resolves to a `Response<FindSchoolsRepDto>`
+  (built via task 1.2); assert `fetch()` sets state to `AsyncData` with the
+  schools. Also test `schoolFilteredProvider` in a `ProviderContainer`:
+  override `schoolSelectionControllerProvider` with seeded data, set
+  `schoolSearchProvider`, and assert filtering matches by school `name` and by
+  `code`.
+
+## 7. settings
+
+- [ ] 7.1 `test/modules/settings/providers/settings_provider_test.dart` — in
+  `setUp` call `TestWidgetsFlutterBinding.ensureInitialized()`,
+  `SharedPreferences.setMockInitialValues({})` and
+  `PackageInfo.setMockInitialValues(...)`. Assert `loadSettings(prefs)`
+  populates the documented defaults (e.g. `dateLimit == 14`,
+  `calendarHourHeight == 60`, `calendarViewType == CalendarViewType.Week`);
+  `getEventColorToSave(null)` / `getEventColorToDisplay(null)` return `null`;
+  `getEventInterfaceColor` returns `event.color` when `colorsByGroup` is false
+  and `event.groupColor` when true.
+
+## 8. onboarding (widget — lowest priority, droppable)
+
+- [ ] 8.1 `test/modules/onboarding/screens/onboarding_screen_test.dart`
+  (widget test) — wrap `OnboardingScreen` in a
+  `ChangeNotifierProvider<SettingsProvider>.value` whose `SettingsProvider` has
+  had `loadSettings` run against `SharedPreferences.setMockInitialValues` (so
+  the `initState` `currentVersion` setter does not throw). Assert the first
+  page text renders, the "Passer" and "Suivant" controls are present, and
+  tapping "Suivant" advances the `PageView` to the second page.
+  If the `initState` plugin coupling makes this disproportionately costly,
+  document why and skip it — the change is complete without 8.1.
+
+## 9. Verification
+
+- [ ] 9.1 Run `flutter test` from `app/` — the whole suite is green
+  (existing A1 tests plus all new tests).
+- [ ] 9.2 Run `flutter analyze` from `app/` — no new issues introduced by the
+  added test files (and `test/support/fixtures.dart`).

--- a/openspec/changes/nominal-core-module-tests/tasks.md
+++ b/openspec/changes/nominal-core-module-tests/tasks.md
@@ -15,57 +15,57 @@ Conventions for every task below:
 
 ## 1. Shared test fixtures
 
-- [ ] 1.1 Create `app/test/support/fixtures.dart` with a `buildCalendarEvent({...})`
+- [x] 1.1 Create `app/test/support/fixtures.dart` with a `buildCalendarEvent({...})`
   builder returning a `CalendarEvent` (implements `EventInterface`) with sane
   defaults for every required field, each overridable — at minimum `uid`,
   `title`, `startsAt`, `endsAt`, `color`, `groupColor`. Used by tasks 2–3.
-- [ ] 1.2 In the same file add `buildSchoolForList({...})` (built_value
+- [x] 1.2 In the same file add `buildSchoolForList({...})` (built_value
   `SchoolForListBuilder`, including the required nested `SchoolAssistant`) and
   `buildFindSchoolsRep(List<SchoolForList>)` returning a `FindSchoolsRepDto`.
   Used by task 6.
 
 ## 2. calendar — pure helpers
 
-- [ ] 2.1 `test/modules/calendar/helpers/events_helper_test.dart` —
+- [x] 2.1 `test/modules/calendar/helpers/events_helper_test.dart` —
   `eventsOverlap` true for overlapping events, false for disjoint events;
   `eventStartsAtHour` / `eventEndsAtHour` return the expected fractional hour
   (e.g. 09:30 → 9.5).
-- [ ] 2.2 `test/modules/calendar/helpers/events_for_week_view_helper_test.dart` —
+- [x] 2.2 `test/modules/calendar/helpers/events_for_week_view_helper_test.dart` —
   `getEventsForWeekView` returns a list of 7 day-buckets; an event is placed in
   the bucket for its start day; an event outside the requested week is excluded.
   Anchor fixtures to `AppDateUtils.dayAtWeekNumber(weekNumber)`.
-- [ ] 2.3 `test/modules/calendar/helpers/events_for_planning_view_helper_test.dart` —
+- [x] 2.3 `test/modules/calendar/helpers/events_for_planning_view_helper_test.dart` —
   `getEventsForPlanningView` returns `[]` for empty input; groups events into
   per-day `EventsByDay` entries; input is sorted by `startsAt`.
 
 ## 3. calendar — event layout model
 
-- [ ] 3.1 `test/modules/calendar/models/ui/event_for_ui_test.dart` —
+- [x] 3.1 `test/modules/calendar/models/ui/event_for_ui_test.dart` —
   `EventForUI.listFromEvents`: non-overlapping events each get `columns == 1`,
   `startColumn == 0`, `endColumn == 1`; two overlapping events get distinct
   columns and `columns == 2`; the result is ordered by `event.startsAt`.
 
 ## 4. calendar — model serialization
 
-- [ ] 4.1 `test/modules/calendar/models/calendar_event_test.dart` —
+- [x] 4.1 `test/modules/calendar/models/calendar_event_test.dart` —
   `CalendarEvent.fromInternalDb(map)` then `.toDbMap()` round-trips the core
   fields (uid, title, colors, dates, location, tags, fields).
-- [ ] 4.2 `test/modules/calendar/models/event_tag_test.dart` —
+- [x] 4.2 `test/modules/calendar/models/event_tag_test.dart` —
   `EventTag.fromDb` → `toDbMap` round-trip preserves `name`/`color`/`icon`;
   `iconData` is populated (a non-null `IconData`) from the `icon` string.
-- [ ] 4.3 `test/modules/calendar/models/calendar_event_custom_fields_test.dart` —
+- [x] 4.3 `test/modules/calendar/models/calendar_event_custom_fields_test.dart` —
   `CalendarEventCustomFields.fromInternalDb` → `toDbMap` round-trips
   `canceled`, `shortDescription`, `subject`, `groupColor`.
 
 ## 5. event_details
 
-- [ ] 5.1 `test/modules/event_details/models/checklist_item_test.dart` —
+- [x] 5.1 `test/modules/event_details/models/checklist_item_test.dart` —
   `ChecklistItem.fromMap` → `toMap` round-trip; the constructor auto-generates a
   `uuid` when none is passed; ISO date strings parse and serialize correctly.
-- [ ] 5.2 `test/modules/event_details/controllers/checklist_focus_controller_test.dart` —
+- [x] 5.2 `test/modules/event_details/controllers/checklist_focus_controller_test.dart` —
   listeners passed to the constructor are invoked by `focusItem`;
   `addListener` registers a new listener; `removeListener` stops notifications.
-- [ ] 5.3 `test/modules/event_details/widgets/event_details_checklist_item_test.dart`
+- [x] 5.3 `test/modules/event_details/widgets/event_details_checklist_item_test.dart`
   (widget test via `pumpApp`) — renders the item content in the `TextField`;
   the `Checkbox` reflects `checklistItem.isChecked`; tapping the checkbox calls
   `onCheckChanged` and tapping the close icon calls `removeItem`. Provide a
@@ -73,7 +73,7 @@ Conventions for every task below:
 
 ## 6. school
 
-- [ ] 6.1 `test/modules/school/controllers/school_selection_controller_test.dart` —
+- [x] 6.1 `test/modules/school/controllers/school_selection_controller_test.dart` —
   construct `SchoolSelectionController` with a `mocktail`-mocked `ApiClient`
   whose `schoolsApi().findSchools()` resolves to a `Response<FindSchoolsRepDto>`
   (built via task 1.2); assert `fetch()` sets state to `AsyncData` with the
@@ -84,7 +84,7 @@ Conventions for every task below:
 
 ## 7. settings
 
-- [ ] 7.1 `test/modules/settings/providers/settings_provider_test.dart` — in
+- [x] 7.1 `test/modules/settings/providers/settings_provider_test.dart` — in
   `setUp` call `TestWidgetsFlutterBinding.ensureInitialized()`,
   `SharedPreferences.setMockInitialValues({})` and
   `PackageInfo.setMockInitialValues(...)`. Assert `loadSettings(prefs)`
@@ -96,7 +96,7 @@ Conventions for every task below:
 
 ## 8. onboarding (widget — lowest priority, droppable)
 
-- [ ] 8.1 `test/modules/onboarding/screens/onboarding_screen_test.dart`
+- [x] 8.1 `test/modules/onboarding/screens/onboarding_screen_test.dart`
   (widget test) — wrap `OnboardingScreen` in a
   `ChangeNotifierProvider<SettingsProvider>.value` whose `SettingsProvider` has
   had `loadSettings` run against `SharedPreferences.setMockInitialValues` (so
@@ -108,7 +108,7 @@ Conventions for every task below:
 
 ## 9. Verification
 
-- [ ] 9.1 Run `flutter test` from `app/` — the whole suite is green
+- [x] 9.1 Run `flutter test` from `app/` — the whole suite is green
   (existing A1 tests plus all new tests).
-- [ ] 9.2 Run `flutter analyze` from `app/` — no new issues introduced by the
+- [x] 9.2 Run `flutter analyze` from `app/` — no new issues introduced by the
   added test files (and `test/support/fixtures.dart`).


### PR DESCRIPTION
## Summary

Phase 1 A3 of the test initiative ([TIM-6](/TIM/issues/TIM-6)): nominal / happy-path unit and widget tests for core modules. **Test-only — no production code is touched.**

- **Shared fixtures** (`test/support/`): `buildCalendarEvent`, `buildSchoolForList`, `buildFindSchoolsRep`, and a `loadSettingsProvider` helper that mocks the SharedPreferences / PackageInfo plugin channels.
- **calendar**: pure helpers (`eventsOverlap`, week/planning view helpers), `EventForUI` layout, and DB round-trip tests for `CalendarEvent` / `EventTag` / `CalendarEventCustomFields`.
- **event_details**: `ChecklistItem`, `ChecklistFocusController`, `EventDetailsChecklistItem` widget.
- **school**: `SchoolSelectionController.fetch` (mocktail-mocked `ApiClient`) and `schoolFilteredProvider` filtering by name/code.
- **settings**: `SettingsProvider` defaults and event-color helpers.
- **onboarding**: `OnboardingScreen` first-page render + page navigation widget test.

## Verification

- `flutter test` — all 48 tests green (A1 foundation + new).
- `flutter analyze` — no issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)