### PR TITLE
refactor: remove duplicated _newActivity init block (TIM-59)

### DIFF
--- a/app/lib/modules/settings/providers/settings_provider.dart
+++ b/app/lib/modules/settings/providers/settings_provider.dart
@@ -103,12 +103,6 @@ class SettingsProvider with ChangeNotifier {
       await prefs!.setBool('new_activity', _newActivityDefault);
     }
 
-    _newActivity = this.prefs.getBool('new_activity');
-    if (_newActivity == null) {
-      _newActivity = _newActivityDefault;
-      await prefs!.setBool('new_activity', _newActivityDefault);
-    }
-
     _calendarHourHeight = this.prefs.getDouble('calendar_hour_height');
     if (_calendarHourHeight == null) {
       _calendarHourHeight = _calendarHourHeightDefault;


### PR DESCRIPTION
## Summary

Removes the duplicated `_newActivity` preference init block in `SettingsProvider.loadSettings` (`app/lib/modules/settings/providers/settings_provider.dart`). The block appeared **twice verbatim**.

The second copy was a behavioural no-op — the re-read of `new_activity` returns the value just written by the first block — so there is no bug fix here, only removal of dead duplication.

Surfaced during B3 review (TIM-58), split out per dev-cycle scope discipline (TIM-57 Simplifier + Reviewer). Independent of the iOS 13→15 gate blocking the rest of Phase 2.

## Verification

- `flutter analyze` on the changed file — no issues
- `flutter test` — 50/50 green

Closes TIM-59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)