### PR TITLE
ci: stop pushing GHCR images on PR builds; pass server image via artifact (TIM-71)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,13 +24,13 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: ./server
-        tags: ${{ env.SERVER_IMAGE_NAME_WITH_TAG }}
+        tags: ghcr.io/timecalendar/timecalendar:${{ github.sha }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         load: true
 
     - name: Save server image to tarball
-      run: docker save ${{ env.SERVER_IMAGE_NAME_WITH_TAG }} -o /tmp/server-image.tar
+      run: docker save ghcr.io/timecalendar/timecalendar:${{ github.sha }} -o /tmp/server-image.tar
 
     - name: Upload server image artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,10 @@ jobs:
         tags: ${{ env.SERVER_IMAGE_NAME_WITH_TAG }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        outputs: type=docker,dest=/tmp/server-image.tar
+        load: true
+
+    - name: Save server image to tarball
+      run: docker save ${{ env.SERVER_IMAGE_NAME_WITH_TAG }} -o /tmp/server-image.tar
 
     - name: Upload server image artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,20 +20,37 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
+    - name: Build server image
+      uses: docker/build-push-action@v4
+      with:
+        context: ./server
+        tags: ${{ env.SERVER_IMAGE_NAME_WITH_TAG }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        outputs: type=docker,dest=/tmp/server-image.tar
+
+    - name: Upload server image artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: server-image
+        path: /tmp/server-image.tar
+        retention-days: 1
+
     - name: Login to image repository
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production'
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push
+    - name: Push server image
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production'
       uses: docker/build-push-action@v4
       with:
         context: ./server
         tags: ${{ env.SERVER_IMAGES_WITH_TAG_TO_PUSH }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
         push: true
 
 
@@ -54,13 +71,14 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Login to image repository
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production'
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push
+    - name: Build (and conditionally push) web image
       uses: docker/build-push-action@v4
       with:
         context: .
@@ -68,7 +86,7 @@ jobs:
         tags: ${{ env.WEB_IMAGES_WITH_TAG_TO_PUSH }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        push: true
+        push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production' }}
 
   test:
     name: Run tests
@@ -79,12 +97,14 @@ jobs:
     - name: Checkout main
       uses: actions/checkout@v4
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+    - name: Download server image artifact
+      uses: actions/download-artifact@v4
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        name: server-image
+        path: /tmp
+
+    - name: Load server image
+      run: docker load -i /tmp/server-image.tar
 
     - name: Start Postgres and Redis
       run: docker compose --env-file ./ci/.env.test -f server/docker-compose.yml up -d


### PR DESCRIPTION
## Summary

Every open dependabot PR was failing because `build-server` / `build-web` push to ghcr.io with `push: true` unconditionally. Dependabot's `GITHUB_TOKEN` is read-only on org packages, so the push step fails, the `test` job (which pulls the just-pushed image by SHA) fails downstream, and the whole pipeline goes red.

This restructures CI so dependency PRs go green again, without changing the main/production deploy path.

## Changes (.github/workflows/build.yaml)

- `build-server`: always builds, saves the image as a tarball (`actions/upload-artifact@v4`), and only pushes to GHCR on `main`/`production`.
- `build-web`: builds on every push; conditionally pushes (`push: \${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production' }}`). Login step skipped on PRs.
- `test`: downloads the artifact and `docker load`s the server image instead of pulling from GHCR. No more GHCR dependency on PRs.
- `deploy`: unchanged — only runs on `main`/`production`, where push still happens.

## Verification

- The YAML still parses; step references unchanged.
- The full pipeline path on this PR will validate the new artifact handoff. If `test` (the job that depended on a successful push) goes green, the fix works.
- A dependabot rerun on any of #52–#66 after this lands should also go green.

## Tech debt unblocked

15 open dependabot PRs (security patches, minor bumps, dev-only updates) that have been red since they opened. Triage + merging of those is the next step on [TIM-70](/TIM/issues/TIM-70).

Closes TIM-71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)