### PR TITLE
refactor: replace raw print/console with structured logging (TIM-74)

### DIFF
--- a/app/lib/modules/activity/repositories/calendar_log_repository.dart
+++ b/app/lib/modules/activity/repositories/calendar_log_repository.dart
@@ -5,6 +5,7 @@ import 'package:timecalendar/modules/activity/models/calendar_change.dart';
 import 'package:timecalendar/modules/activity/models/calendar_log_event.dart';
 import 'package:timecalendar/modules/database/providers/simple_database.dart';
 import 'package:timecalendar/modules/shared/clients/timecalendar_client.dart';
+import 'package:timecalendar/modules/shared/utils/app_logger.dart';
 import 'package:timecalendar_api/timecalendar_api.dart';
 
 class CalendarLogRepository {
@@ -45,7 +46,11 @@ class CalendarLogRepository {
 
       return calendarLogs;
     } catch (error) {
-      print('error: $error');
+      AppLogger.error(
+        'Failed to fetch calendar logs from API, falling back to cache',
+        name: 'activity',
+        error: error,
+      );
       // If API call fails, return cached data
       return getCalendarLogsFromCache();
     }

--- a/app/lib/modules/calendar/models/ui/event_for_ui.dart
+++ b/app/lib/modules/calendar/models/ui/event_for_ui.dart
@@ -47,9 +47,6 @@ class EventForUI {
       int endColumn = 1;
       int columns = 1;
 
-      // print('---');
-      // print(calendarEvent.event.title);
-
       // Check events before the current event
       List<EventForUI> overlapEvents = [];
       getOverlapEventsBefore(
@@ -78,24 +75,17 @@ class EventForUI {
         int maxInsertPosition = -1;
         int maxInsertColumns = 0;
 
-        // print('Overlaps: ');
-        // print(overlapEvents.map((e) => e.event.title));
-
         for (int columnIndex = 0; columnIndex < oldColumns; columnIndex++) {
           // Get events of the current column
           List<EventForUI> overlapsOfColumn = overlapEvents.where((ev) {
             return ev.startColumn <= columnIndex && ev.endColumn > columnIndex;
           }).toList();
-          // print(
-          //     '    Column $columnIndex (${overlapsOfColumn.map((e) => e.event.title)}) :');
 
           // Find the largest column where we can fit the event
           bool eventOverlapInColumn = false;
           for (EventForUI overlapOfColumn in overlapsOfColumn) {
             if (eventsOverlap(calendarEvent.event, overlapOfColumn.event)) {
               eventOverlapInColumn = true;
-              // print(
-              //     '      > OVERLAP - Overlap by ${overlapOfColumn.event.title}');
               break;
             }
           }
@@ -106,8 +96,6 @@ class EventForUI {
             insertColumns = 0;
             continue;
           }
-
-          // print('      > OK - There is space !');
 
           // We can insert in this position
           if (insertPosition == -1) {
@@ -124,12 +112,9 @@ class EventForUI {
 
         if (maxInsertPosition != -1) {
           // Insert in an existing column
-          // print('Insert in existing column, $maxInsertColumns');
           startColumn = maxInsertPosition;
           endColumn = maxInsertPosition + maxInsertColumns;
           columns = oldColumns;
-
-          // print('  > EXISTING - There is space in existing column');
         } else {
           // Add a new column
           // Resize these events
@@ -143,14 +128,8 @@ class EventForUI {
           startColumn = oldColumns;
           endColumn = newColumns;
           columns = newColumns;
-
-          // print('  > NEW_COL - Add a new column');
         }
-      } else {
-        // print('  > OK - There is space');
       }
-
-      // print('  > Placed at $startColumn - $endColumn (columns: $columns)');
 
       // Set the new event column position
       calendarEvent.startColumn = startColumn;

--- a/app/lib/modules/firebase/services/notification/notification.dart
+++ b/app/lib/modules/firebase/services/notification/notification.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:timecalendar/modules/shared/utils/app_logger.dart';
 
 typedef NotificationListener = Function(Map<String, dynamic> message);
 
@@ -38,13 +39,17 @@ class NotificationService {
     }
 
     return _firebaseMessaging.getToken().catchError((error) {
-      print('Error getting FCM token: $error');
+      AppLogger.error(
+        'Error getting FCM token',
+        name: 'notification',
+        error: error,
+      );
       return null;
     });
   }
 
   Future<dynamic> onMessage(Map<String, dynamic> message) async {
-    print('New notification: ' + message.toString());
+    AppLogger.info('New notification: $message', name: 'notification');
     if (message['action'] != null) {
       handleNotification(message);
     }
@@ -111,7 +116,11 @@ class NotificationService {
         sound: true,
       );
     } catch (e) {
-      print(e);
+      AppLogger.error(
+        'Failed to request notification permission',
+        name: 'notification',
+        error: e,
+      );
     }
   }
 

--- a/app/lib/modules/import_ical/hooks/use_import_ical_controller.dart
+++ b/app/lib/modules/import_ical/hooks/use_import_ical_controller.dart
@@ -10,6 +10,7 @@ import 'package:timecalendar/modules/import_ical/hooks/use_loading_dialog.dart';
 import 'package:timecalendar/modules/import_ical/providers/ical_url_provider.dart';
 import 'package:timecalendar/modules/shared/clients/timecalendar_client.dart';
 import 'package:timecalendar/modules/shared/constants/constants.dart';
+import 'package:timecalendar/modules/shared/utils/app_logger.dart';
 import 'package:timecalendar/modules/shared/utils/url_launcher.dart';
 import 'package:timecalendar/modules/suggestion/screens/suggestion_screen.dart';
 import 'package:timecalendar_api/timecalendar_api.dart';
@@ -107,7 +108,11 @@ ImportIcalState useImportIcalController(BuildContext context, WidgetRef ref) {
         return NotificationService().subscribeDelay();
       });
     } catch (e) {
-      print(e);
+      AppLogger.error(
+        'Failed to import iCal calendar',
+        name: 'import_ical',
+        error: e,
+      );
       Future.delayed(Duration(milliseconds: 50)).then((_) {
         loadingDialog.closeDialog();
       });

--- a/app/lib/modules/school/screens/school_selection/school_list.dart
+++ b/app/lib/modules/school/screens/school_selection/school_list.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:timecalendar/modules/school/controllers/school_selection_controller.dart';
 import 'package:timecalendar/modules/school/screens/school_selection/school_item.dart';
 import 'package:timecalendar/modules/school/screens/school_selection/school_not_found_button.dart';
+import 'package:timecalendar/modules/shared/utils/app_logger.dart';
 import 'package:timecalendar_api/timecalendar_api.dart';
 
 class SchoolList extends HookConsumerWidget {
@@ -26,8 +27,12 @@ class SchoolList extends HookConsumerWidget {
 
     schools.whenOrNull(
       error: (err, stack) {
-        print(err);
-        print(stack);
+        AppLogger.error(
+          'Failed to load school list',
+          name: 'school',
+          error: err,
+          stackTrace: stack,
+        );
       },
     );
 

--- a/app/lib/modules/shared/utils/app_logger.dart
+++ b/app/lib/modules/shared/utils/app_logger.dart
@@ -1,0 +1,32 @@
+import 'dart:developer' as developer;
+
+/// Lightweight structured logging wrapper around `dart:developer`.
+///
+/// Replaces ad-hoc `print()` calls in production code. Unlike `print`, these
+/// entries carry a level and a source name, are routed to the Dart VM service
+/// (so they show up in DevTools), and are stripped from `print`-style stdout
+/// noise in release builds.
+class AppLogger {
+  const AppLogger._();
+
+  /// Informational message — expected, non-error events.
+  static void info(String message, {String name = 'timecalendar'}) {
+    developer.log(message, name: name, level: 800);
+  }
+
+  /// Recoverable problem — something failed but the app keeps working.
+  static void error(
+    String message, {
+    String name = 'timecalendar',
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    developer.log(
+      message,
+      name: name,
+      level: 1000,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+}

--- a/server/src/modules/redis/services/redis.service.ts
+++ b/server/src/modules/redis/services/redis.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, OnModuleDestroy } from "@nestjs/common"
+import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common"
 import { REDIS_KEY_PREFIX, REDIS_URL } from "config/constants"
 import Redis, { RedisOptions } from "ioredis"
 
 @Injectable()
 export class RedisService implements OnModuleDestroy {
+  private readonly logger = new Logger(RedisService.name)
   private client: Redis | null = null
 
   onModuleDestroy() {
@@ -23,7 +24,7 @@ export class RedisService implements OnModuleDestroy {
 
   newRedisInstance(options: RedisOptions = {}) {
     const redis = new Redis(REDIS_URL, options)
-    redis.on("error", (err) => console.error(err))
+    redis.on("error", (err) => this.logger.error("Redis connection error", err))
     return redis
   }
 

--- a/server/src/modules/school/services/school-profile-generation.service.ts
+++ b/server/src/modules/school/services/school-profile-generation.service.ts
@@ -140,7 +140,6 @@ export class SchoolProfileGenerationService {
       this.logger.log(`Successfully saved profile for school ID: ${schoolId}`)
       return savedProfile
     } catch (error) {
-      console.error(error)
       this.logger.error(
         `Failed to generate profile for school ${school.name}:`,
         error,


### PR DESCRIPTION
## Summary

Day-two tech-debt work from the [TIM-70](/TIM/issues/TIM-70) sweep. Production code logged via raw `print()` (Dart) and `console.error()` (NestJS services) — unstructured, no level/source, and noise in release builds.

## Flutter (`app/lib/`)

- New **`AppLogger`** (`shared/utils/app_logger.dart`) — a thin wrapper over `dart:developer` `log()` with `info` / `error` levels and a source name. No new dependency; follows the existing static-utility convention (`ColorUtils`, `AppDateUtils`).
- Migrated **7 `print()` calls**: notification service (FCM token error, new-message, permission failure), school-list load error, iCal import failure, calendar-log API fallback.
- Deleted **dead commented-out debug `print` blocks** in `event_for_ui.dart` (~11 lines of noise in the column-layout algorithm).

## NestJS (`server/src/`)

- `RedisService` connection-error handler → injected `Logger`.
- `school-profile-generation.service.ts` — dropped a redundant `console.error(error)` (the very next line already `logger.error`s the same error).
- `server/src/scripts/*` console output left as-is — intentional CLI tooling I/O, out of scope.

## Verification

- `flutter analyze` — clean on all touched files.
- `flutter test` — 50/50 green.
- `tsc --noEmit` — clean.

Closes TIM-74. Parent: [TIM-70](/TIM/issues/TIM-70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)