### PR TITLE
refactor(app): type the notification listener collections (TIM-82)

### DIFF
--- a/app/lib/modules/firebase/services/notification/notification.dart
+++ b/app/lib/modules/firebase/services/notification/notification.dart
@@ -3,7 +3,11 @@ import 'dart:io';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:timecalendar/modules/shared/utils/app_logger.dart';
 
-typedef NotificationListener = Function(Map<String, dynamic> message);
+/// A handler for an incoming push notification payload.
+///
+/// Named `NotificationCallback` rather than `NotificationListener` to avoid
+/// shadowing Flutter's own `NotificationListener<T>` widget.
+typedef NotificationCallback = void Function(Map<String, dynamic> message);
 
 class NotificationAction {
   static const String CALENDAR_CHANGED = 'calendar_changed';
@@ -13,8 +17,7 @@ class NotificationService {
   static final NotificationService _instance = NotificationService._();
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
 
-  final List<Function> calendarUpdateListeners = [];
-  final Map<String, List<Function>> listeners = {};
+  final Map<String, List<NotificationCallback>> listeners = {};
 
   factory NotificationService() {
     return _instance;
@@ -88,7 +91,7 @@ class NotificationService {
     });
   }
 
-  void addEventListener(String action, NotificationListener listener) {
+  void addEventListener(String action, NotificationCallback listener) {
     if (!this.listeners.containsKey(action)) {
       this.listeners[action] = [];
     }
@@ -96,7 +99,7 @@ class NotificationService {
     this.listeners[action]!.add(listener);
   }
 
-  void removeEventListener(String action, NotificationListener listener) {
+  void removeEventListener(String action, NotificationCallback listener) {
     if (!this.listeners.containsKey(action)) {
       return;
     }


### PR DESCRIPTION
## Summary

`NotificationService` held its listener collections loosely typed.

- `List<Function> calendarUpdateListeners` — declared but **never read** anywhere in the codebase; removed as dead code.
- `Map<String, List<Function>> listeners` → `Map<String, List<NotificationCallback>>`.
- The `NotificationListener` typedef → renamed `NotificationCallback`. The old name **shadowed Flutter's own `NotificationListener<T>` widget**. Also given an explicit `void` return type. It's an internal typedef and callers pass closures, so the rename is not a breaking change.

## Verification

- `flutter analyze` — clean.
- `flutter test` — 57/57 green.

Closes TIM-82. Parent: [TIM-70](/TIM/issues/TIM-70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)