### PR TITLE
fix(ci): point Dependabot npm config at the workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,27 +16,18 @@ updates:
           - "minor"
           - "patch"
 
-  # Next.js web app
+  # Root npm workspace: web + generated OpenAPI JavaScript client.
+  # Must point at "/" (where package-lock.json lives): pointing at a
+  # workspace member updates only its package.json, leaving the root
+  # lockfile out of sync and breaking `npm ci`.
   - package-ecosystem: "npm"
-    directory: "/web"
+    directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
       dev-and-minor:
         dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # Generated OpenAPI JavaScript client
-  - package-ecosystem: "npm"
-    directory: "/openapi/javascript"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    groups:
-      dev-and-minor:
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Why

Every Dependabot PR for `/web` (#103, #104, #105, #106, #108) failed the **Build web image** check with:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
```

`web/` and `openapi/javascript/` are npm-workspace members; the lockfile lives at the repo root. With `directory: "/web"`, Dependabot only edits `web/package.json` and never touches the root `package-lock.json`, so `npm ci` is guaranteed to fail on every one of its PRs.

## What

Replace the `/web` and `/openapi/javascript` npm entries with a single entry at `directory: "/"` — Dependabot's npm ecosystem handles workspaces from the lockfile root and updates member manifests plus the root lockfile together.

The broken `/web` PRs are closed; Dependabot will recreate the still-relevant updates from the root config on its next weekly run, this time with a consistent lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)